### PR TITLE
Support both URI and hostnames in configuration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -68,10 +68,17 @@ export const getConfig = async (overrideConfigPath?: string): Promise<FixLockFil
         ...cosmiconfigResult?.config as FixLockFileIntegrityConfig,
         registries: (cosmiconfigResult?.config?.registries as string[])?.map((registry: string) => {
             try {
+                // Assume it is a URL
                 return new URL(registry);
             }
             catch (e) {
-                logger.warn(`Invalid registry URL in configuration: chalk.red(${registry})`);
+                try {
+                    // Assume it is a hostname
+                    new URL(`https://${registry}`);
+                }
+                catch (e) {
+                    logger.warn(`Invalid registry URL in configuration: chalk.red(${registry})`);
+                }
             }
         }).filter(Boolean),
         prettier: prettierConfig

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -128,6 +128,6 @@ describe("Test config", () => {
             }
         });
         expect(console.warn).toHaveBeenCalledTimes(1);
-        expect(console.warn).toHaveBeenCalledWith("Invalid registry URL in configuration: chalk.red(invalidUrl)");
+        expect(console.warn).toHaveBeenCalledWith("Invalid registry URL in configuration: chalk.red(invalid[::]Url)");
     });
 });

--- a/test/resources/.fix-lockfile-invalid-url.json
+++ b/test/resources/.fix-lockfile-invalid-url.json
@@ -1,7 +1,7 @@
 {
     "includePaths": ["./", "./packages/a", "./packages/b"],
     "lockFileNames": ["package-lock.json"],
-    "registries": ["https://www.goodurl.com", "invalidUrl"],
+    "registries": ["https://www.goodurl.com", "invalid[::]Url"],
     "prettier": {
         "useTabs": true,
         "endOfLine": "cr"


### PR DESCRIPTION
Support both URI (i.e. https://registry.npmjs.org) and hostnames (i.e. registry.npmjs.org) in configuration