### PR TITLE
fix: Add suggested configuration for a Lerna monorepo project (generic)

### DIFF
--- a/.fix-lockfile.lerna.json
+++ b/.fix-lockfile.lerna.json
@@ -1,0 +1,10 @@
+{
+    "includePaths": [
+        "./",
+        "./packages/*"
+    ],
+    "lockFileNames": [
+        "package-lock.json",
+        "npm-shrinkwrap.json"
+    ]
+}


### PR DESCRIPTION
Closes #68

Patch generated by `qwen3.6-35b-a3b via local API`.