### PR TITLE
Fix redundant warning for workspace link entries in lockfile

### DIFF
--- a/src/fixLockfileIntegrity.ts
+++ b/src/fixLockfileIntegrity.ts
@@ -123,7 +123,9 @@ export const fixLockFile = async (lockFileLocation: string): Promise<FixLockFile
     let hashesFound: Set<string> = new Set<string>();
     traverse(lockFile).forEach(function(node) {
         let resolvedUrl: URL;
-        if (node.resolved) {
+        // A workspace link entry holds a relative path in "resolved" and holds no integrity.
+        // Therefore the tool parses the URL only for an entry that needs a fix
+        if (node.resolved && node.integrity?.startsWith("sha1-")) {
             try {
                 resolvedUrl = new URL(node.resolved);
             }

--- a/test/fixLockfileIntegrity.test.ts
+++ b/test/fixLockfileIntegrity.test.ts
@@ -51,6 +51,19 @@ const LOCKFILE_V2_SCOPED_PACKAGE = {
     }
 };
 
+// npm records a workspace package as a link. "resolved" holds a relative path and there is no integrity
+const LOCKFILE_V2_WORKSPACE_LINK = {
+    "node_modules/@scopeName/a": {
+        resolved: "packages/a",
+        link: true
+    },
+    "node_modules/packageName": {
+        version: "1.0.0",
+        resolved: "https://registry.npmjs.org/packageName/-/packageName-1.0.0.tgz",
+        integrity: SHA1
+    }
+};
+
 describe("Test fix lockfile integrity", () => {
     describe("Test registry parsing from resolved field", () => {
         it("Test simple package name", () => {
@@ -208,6 +221,19 @@ describe("Test fix lockfile integrity", () => {
             expect(global.fetch).toHaveBeenCalledTimes(1);
             const expectedJsonString = jsonString.replace(SHA1, SHA512);
             expect(fsPromises.writeFile).toHaveBeenCalledWith("fileLocation", expectedJsonString, "utf8");
+        });
+
+        it("Should not warn about a workspace link entry", async () => {
+            const jsonString = JSON.stringify(LOCKFILE_V2_WORKSPACE_LINK, null, 2) + "\n";
+            jest.spyOn(fsPromises, "readFile").mockResolvedValue(jsonString);
+            jest.spyOn(fsPromises, "writeFile").mockImplementation(async () => {});
+            jest.spyOn(logger, "warn").mockImplementation(() => {});
+
+            const result: FixLockFileResult = await fixLockFile("fileLocation");
+
+            expect(result).toEqual(FixLockFileResult.FILE_FIXED);
+            expect(logger.warn).not.toHaveBeenCalled();
+            expect(fsPromises.writeFile).toHaveBeenCalledWith("fileLocation", jsonString.replace(SHA1, SHA512), "utf8");
         });
 
         it("Should handle lock file version 1 - scoped package", async () => {


### PR DESCRIPTION
* Skip URL parsing for entries without a SHA1 integrity hash. A workspace link entry holds a relative path in "resolved" and has no integrity field. The parser treated this path as a URL and logged a false warning.
* Add a test fixture for a lockfile with a workspace link entry mixed with a regular package.
* Add a test that checks no warning happens for a workspace link entry.